### PR TITLE
Add block targets for navigation rules

### DIFF
--- a/src/lib/survey/blocks/ConditionalBlock.tsx
+++ b/src/lib/survey/blocks/ConditionalBlock.tsx
@@ -64,10 +64,10 @@ return fieldA === "Yes";`}
           <div className="text-xs text-muted-foreground bg-muted p-3 rounded space-y-2">
             <strong>Examples:</strong>
             <div className="space-y-1">
-              <code className="block">return age >= 18;</code>
-              <code className="block">return income > 50000 && hasInsurance === true;</code>
-              <code className="block">return bmiCalculator?.category === "Overweight";</code>
-              <code className="block">return answers.includes("Option A");</code>
+              <code className="block">{"return age >= 18;"}</code>
+              <code className="block">{"return income > 50000 && hasInsurance === true;"}</code>
+              <code className="block">{"return bmiCalculator?.category === 'Overweight';"}</code>
+              <code className="block">{"return answers.includes('Option A');"}</code>
             </div>
           </div>
         </div>

--- a/src/lib/survey/types/index.ts
+++ b/src/lib/survey/types/index.ts
@@ -2,6 +2,13 @@ import type { ReactNode } from "react";
 
 export type UUID = string;
 
+export interface NavigationRule {
+  condition: string;
+  target: UUID | string;
+  isPage?: boolean;
+  isDefault?: boolean;
+}
+
 export interface NodeData {
   uuid?: UUID;
   name?: string;
@@ -30,6 +37,7 @@ export interface BlockData {
   defaultValue?: any;
   className?: string;
   showResults?: boolean;
+  navigationRules?: NavigationRule[];
   [key: string]: any;
 }
 

--- a/src/packages/survey-form-builder/src/components/common/NavigationRulesEditor.tsx
+++ b/src/packages/survey-form-builder/src/components/common/NavigationRulesEditor.tsx
@@ -1,0 +1,311 @@
+import React from "react";
+import { Label } from "@/components/ui/label";
+import { Input } from "@/components/ui/input";
+import { Button } from "@/components/ui/button";
+import { Checkbox } from "@/components/ui/checkbox";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+  SelectGroup,
+  SelectLabel,
+} from "@/components/ui/select";
+import { useSurveyBuilder } from "../../context/SurveyBuilderContext";
+import type { BlockData, NavigationRule } from "../../types";
+
+interface Props {
+  data: BlockData;
+  onUpdate?: (data: BlockData) => void;
+}
+
+interface RuleState {
+  field: string;
+  operator: string;
+  value: string;
+  target: string;
+  isPage?: boolean;
+  isDefault?: boolean;
+}
+
+function parseRule(rule: NavigationRule): RuleState {
+  const match = rule.condition.match(
+    /^(\w+)\s*(==|!=|>=|<=|>|<|contains|startsWith|endsWith)\s*(.+)$/
+  );
+  if (match) {
+    const [, field, operator, value] = match;
+    return {
+      field,
+      operator,
+      value: value.replace(/^['"]|['"]$/g, ""),
+      target: String(rule.target),
+      isPage: rule.isPage,
+      isDefault: rule.isDefault,
+    };
+  }
+  return {
+    field: "",
+    operator: "==",
+    value: "",
+    target: String(rule.target),
+    isPage: rule.isPage,
+    isDefault: rule.isDefault,
+  };
+}
+
+function buildRule(state: RuleState): NavigationRule {
+  if (state.isDefault) {
+    return {
+      condition: "true",
+      target: state.target,
+      isPage: state.isPage,
+      isDefault: true,
+    };
+  }
+  return {
+    condition: `${state.field} ${state.operator} ${JSON.stringify(state.value)}`,
+    target: state.target,
+    isPage: state.isPage,
+    isDefault: state.isDefault,
+  };
+}
+
+export const NavigationRulesEditor: React.FC<Props> = ({ data, onUpdate }) => {
+  const { state } = useSurveyBuilder();
+
+  const collectFieldNames = React.useCallback((node: any): string[] => {
+    if (!node) return [];
+    let names: string[] = [];
+    if (node.fieldName) names.push(node.fieldName);
+    if (Array.isArray(node.items)) {
+      for (const item of node.items) {
+        names = names.concat(collectFieldNames(item));
+      }
+    }
+    if (Array.isArray(node.nodes)) {
+      for (const n of node.nodes) {
+        if (typeof n !== "string") {
+          names = names.concat(collectFieldNames(n));
+        }
+      }
+    }
+    return names;
+  }, []);
+
+  const collectPages = React.useCallback((node: any) => {
+    if (!node) return [] as Array<{ uuid: string; name: string }>;
+    let pages: Array<{ uuid: string; name: string }> = [];
+    if (node.type === "set") {
+      pages.push({ uuid: node.uuid || "", name: node.name || node.uuid || "Page" });
+    }
+    if (Array.isArray(node.items)) {
+      for (const item of node.items) {
+        pages = pages.concat(collectPages(item));
+      }
+    }
+    if (Array.isArray(node.nodes)) {
+      for (const n of node.nodes) {
+        if (typeof n !== "string") {
+          pages = pages.concat(collectPages(n));
+        }
+      }
+    }
+    return pages;
+  }, []);
+
+  const collectBlocks = React.useCallback((node: any) => {
+    if (!node) return [] as Array<{ uuid: string; name: string }>;
+    let blocks: Array<{ uuid: string; name: string }> = [];
+    if (node.type !== "set") {
+      blocks.push({
+        uuid: node.uuid || "",
+        name: node.name || node.fieldName || node.uuid || "Block",
+      });
+    }
+    if (Array.isArray(node.items)) {
+      for (const item of node.items) {
+        blocks = blocks.concat(collectBlocks(item));
+      }
+    }
+    if (Array.isArray(node.nodes)) {
+      for (const n of node.nodes) {
+        if (typeof n !== "string") {
+          blocks = blocks.concat(collectBlocks(n));
+        }
+      }
+    }
+    return blocks;
+  }, []);
+
+  const fieldOptions = React.useMemo(() => collectFieldNames(state.rootNode), [state.rootNode]);
+  const pageOptions = React.useMemo(() => collectPages(state.rootNode), [state.rootNode]);
+  const blockOptions = React.useMemo(() => collectBlocks(state.rootNode), [state.rootNode]);
+
+  const [rules, setRules] = React.useState<RuleState[]>(() => {
+    return (data.navigationRules || []).map(parseRule);
+  });
+
+  React.useEffect(() => {
+    const converted = rules.map(buildRule);
+    onUpdate?.({ ...data, navigationRules: converted });
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [rules]);
+
+  const handleRuleChange = (index: number, field: keyof RuleState, value: any) => {
+    setRules((prev) => {
+      const newRules = [...prev];
+      newRules[index] = { ...newRules[index], [field]: value };
+      return newRules;
+    });
+  };
+
+  const handleTargetChange = (index: number, val: string) => {
+    if (val === "submit") {
+      setRules((prev) => {
+        const newRules = [...prev];
+        newRules[index] = { ...newRules[index], target: "submit", isPage: false };
+        return newRules;
+      });
+      return;
+    }
+    const [kind, uuid] = val.split(":");
+    setRules((prev) => {
+      const newRules = [...prev];
+      newRules[index] = { ...newRules[index], target: uuid, isPage: kind === "page" };
+      return newRules;
+    });
+  };
+
+  const addRule = () => {
+    setRules((prev) => [
+      ...prev,
+      { field: "", operator: "==", value: "", target: "", isPage: true },
+    ]);
+  };
+
+  const removeRule = (index: number) => {
+    setRules((prev) => prev.filter((_, i) => i !== index));
+  };
+
+  return (
+    <div className="space-y-4 mt-4">
+      <Label>Navigation Rules</Label>
+      {rules.map((rule, idx) => (
+        <div key={idx} className="border rounded-md p-3 space-y-2">
+          <div className="grid grid-cols-4 gap-2">
+            <div className="space-y-1">
+              <Label>Variable</Label>
+              <Select
+                value={rule.field}
+                onValueChange={(val) => handleRuleChange(idx, "field", val)}
+              >
+                <SelectTrigger>
+                  <SelectValue placeholder="Select field" />
+                </SelectTrigger>
+                <SelectContent>
+                  {fieldOptions.map((name) => (
+                    <SelectItem key={name} value={name}>
+                      {name}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+            </div>
+            <div className="space-y-1">
+              <Label>Operator</Label>
+              <Select
+                value={rule.operator}
+                onValueChange={(val) => handleRuleChange(idx, "operator", val)}
+              >
+                <SelectTrigger>
+                  <SelectValue placeholder="Operator" />
+                </SelectTrigger>
+                <SelectContent>
+                  {[
+                    "==",
+                    "!=",
+                    ">",
+                    ">=",
+                    "<",
+                    "<=",
+                    "contains",
+                  ].map((op) => (
+                    <SelectItem key={op} value={op}>
+                      {op}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+            </div>
+            <div className="space-y-1">
+              <Label>Value</Label>
+              <Input
+                value={rule.value}
+                onChange={(e) => handleRuleChange(idx, "value", e.target.value)}
+              />
+            </div>
+            <div className="space-y-1">
+              <Label>Target</Label>
+              <Select
+                value={
+                  rule.target === "submit"
+                    ? "submit"
+                    : rule.isPage
+                      ? `page:${rule.target}`
+                      : `block:${rule.target}`
+                }
+                onValueChange={(val) => handleTargetChange(idx, val)}
+              >
+                <SelectTrigger>
+                  <SelectValue placeholder="Choose" />
+                </SelectTrigger>
+                <SelectContent>
+                  <SelectGroup>
+                    <SelectLabel>Pages</SelectLabel>
+                    {pageOptions.map((p) => (
+                      <SelectItem key={`page-${p.uuid}`} value={`page:${p.uuid}`}>
+                        {p.name}
+                      </SelectItem>
+                    ))}
+                  </SelectGroup>
+                  <SelectGroup>
+                    <SelectLabel>Blocks</SelectLabel>
+                    {blockOptions.map((b) => (
+                      <SelectItem key={`block-${b.uuid}`} value={`block:${b.uuid}`}>
+                        {b.name}
+                      </SelectItem>
+                    ))}
+                  </SelectGroup>
+                  <SelectItem value="submit">Submit</SelectItem>
+                </SelectContent>
+              </Select>
+            </div>
+          </div>
+          <div className="flex items-center gap-2">
+            <Checkbox
+              id={`default-${idx}`}
+              checked={rule.isDefault || false}
+              onCheckedChange={(checked) =>
+                handleRuleChange(idx, "isDefault", !!checked)
+              }
+            />
+            <Label htmlFor={`default-${idx}`}>Default</Label>
+            <Button
+              type="button"
+              variant="outline"
+              size="sm"
+              onClick={() => removeRule(idx)}
+              className="ml-auto"
+            >
+              Remove
+            </Button>
+          </div>
+        </div>
+      ))}
+      <Button type="button" variant="outline" size="sm" onClick={addRule}>
+        Add Rule
+      </Button>
+    </div>
+  );
+};

--- a/src/packages/survey-form-builder/src/survey/blocks/ContentBlockItem.tsx
+++ b/src/packages/survey-form-builder/src/survey/blocks/ContentBlockItem.tsx
@@ -4,6 +4,7 @@ import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader, CardFooter } from "@/components/ui/card";
 import { useSurveyBuilder } from "../../context/SurveyBuilderContext";
 import { BlockData } from "../../types";
+import { NavigationRulesEditor } from "../../components/common/NavigationRulesEditor";
 import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogTrigger } from "@/components/ui/dialog";
 
 interface ContentBlockItemProps {
@@ -77,6 +78,7 @@ export const ContentBlockItem: React.FC<ContentBlockItemProps> = ({
                     onRemove();
                   },
                 })}
+                <NavigationRulesEditor data={data} onUpdate={onUpdate} />
               </div>
             </DialogContent>
           </Dialog>

--- a/src/packages/survey-form-builder/src/types.ts
+++ b/src/packages/survey-form-builder/src/types.ts
@@ -2,6 +2,13 @@ import type { JSX, ReactNode } from "react";
 
 export type UUID = string;
 
+export interface NavigationRule {
+  condition: string;
+  target: UUID | string;
+  isPage?: boolean;
+  isDefault?: boolean;
+}
+
 export interface NodeData {
   uuid?: UUID;
   name?: string;
@@ -30,6 +37,7 @@ export interface BlockData {
   defaultValue?: any;
   className?: string;
   showResults?: boolean;
+  navigationRules?: NavigationRule[];
   [key: string]: any;
 }
 

--- a/src/packages/survey-form-renderer/src/context/SurveyFormContext.tsx
+++ b/src/packages/survey-form-renderer/src/context/SurveyFormContext.tsx
@@ -13,7 +13,8 @@ import {
   evaluateCondition,
   isBlockVisible,
   executeCalculation,
-  getNextPageIndex
+  getNextPageIndex as calculateNextPageIndex,
+  getNextPageFromNavigationRules
 } from "../utils/conditionalUtils";
 
 // Create context with default values
@@ -184,7 +185,7 @@ export const SurveyFormProvider: React.FC<SurveyFormProviderProps> = ({
 
     // If we found branching logic, use it to determine the next page
     if (branchingLogic) {
-      const nextIndex = getNextPageIndex(
+      const nextIndex = calculateNextPageIndex(
         currentPage,
         branchingLogic,
         { ...values, ...computedValues },
@@ -197,6 +198,16 @@ export const SurveyFormProvider: React.FC<SurveyFormProviderProps> = ({
       }
 
       return nextIndex;
+    }
+
+    // Check navigation rules on blocks
+    const navIndex = getNextPageFromNavigationRules(
+      currentPageBlocks,
+      pages,
+      { ...values, ...computedValues }
+    );
+    if (navIndex !== null) {
+      return navIndex === -1 ? null : navIndex;
     }
 
     // Default to next page

--- a/src/packages/survey-form-renderer/src/types.ts
+++ b/src/packages/survey-form-renderer/src/types.ts
@@ -171,6 +171,13 @@ export interface BranchingLogic {
   message?: string;
 }
 
+export interface NavigationRule {
+  condition: string;
+  target: string;
+  isPage?: boolean;
+  isDefault?: boolean;
+}
+
 export interface CalculationRule {
   formula: string;
   targetField: string;


### PR DESCRIPTION
## Summary
- allow selecting blocks as navigation targets in the builder
- evaluate navigation rules for block targets by finding their page

## Testing
- `bun x biome lint .`
- `bun run type-check` *(fails: Cannot find module 'react' or its corresponding type declarations)*

------
https://chatgpt.com/codex/tasks/task_e_6846e0c36320832c8674055b5aa362d1