### PR TITLE
Add block navigation and update condition parser

### DIFF
--- a/src/packages/survey-form-renderer/src/components/layouts/StepperLayout.tsx
+++ b/src/packages/survey-form-renderer/src/components/layouts/StepperLayout.tsx
@@ -64,18 +64,20 @@ export const StepperLayout: React.FC<StepperLayoutProps> = ({
 
   const {
     currentPage,
+    currentBlockIndex,
     totalPages,
     values,
     setValue,
     errors,
-    goToNextPage,
-    goToPreviousPage,
+    goToNextBlock,
+    goToPreviousBlock,
     isFirstPage,
     isLastPage,
     submit,
     isValid,
     theme,
-    goToPage
+    goToPage,
+    surveyData
   } = useSurveyForm();
 
   const themeConfig = themes[theme] || themes.default;
@@ -83,7 +85,7 @@ export const StepperLayout: React.FC<StepperLayoutProps> = ({
 
   // Get all survey pages
   const { getSurveyPages } = require('../../utils/surveyUtils');
-  const pages = getSurveyPages(useSurveyForm().surveyData.rootNode);
+  const pages = getSurveyPages(surveyData.rootNode);
 
   // Handle form submission
   const handleSubmit = (e: React.FormEvent) => {
@@ -165,16 +167,19 @@ export const StepperLayout: React.FC<StepperLayoutProps> = ({
           <CardContent>
             {/* Page content */}
             <div className="survey-page-content space-y-6">
-              {pages[currentPage]?.map((block, index) => (
+              {pages[currentPage] && pages[currentPage][currentBlockIndex] && (
                 <BlockRenderer
-                  key={block.uuid || `block-${index}`}
-                  block={block}
-                  value={block.fieldName ? values[block.fieldName] : undefined}
-                  onChange={(value) => block.fieldName && setValue(block.fieldName, value)}
-                  error={block.fieldName ? errors[block.fieldName] : undefined}
+                  key={pages[currentPage][currentBlockIndex].uuid || `block-${currentBlockIndex}`}
+                  block={pages[currentPage][currentBlockIndex]}
+                  value={pages[currentPage][currentBlockIndex].fieldName ? values[pages[currentPage][currentBlockIndex].fieldName as string] : undefined}
+                  onChange={(value) => {
+                    const field = pages[currentPage][currentBlockIndex].fieldName;
+                    if (field) setValue(field, value);
+                  }}
+                  error={pages[currentPage][currentBlockIndex].fieldName ? errors[pages[currentPage][currentBlockIndex].fieldName as string] : undefined}
                   theme={theme}
                 />
-              ))}
+              )}
             </div>
 
             {/* Debug information */}
@@ -183,9 +188,9 @@ export const StepperLayout: React.FC<StepperLayoutProps> = ({
             {/* Navigation buttons */}
             <div className="mt-6">
               <NavigationButtons
-                onPrevious={!isFirstPage ? goToPreviousPage : undefined}
-                onNext={!isLastPage ? goToNextPage : undefined}
-                onSubmit={isLastPage ? submit : undefined}
+                onPrevious={!isFirstPage || currentBlockIndex > 0 ? goToPreviousBlock : undefined}
+                onNext={goToNextBlock}
+                onSubmit={isLastPage && currentBlockIndex === pages[currentPage].length - 1 ? submit : undefined}
                 isValid={isValid}
                 options={navigationButtons}
                 submitText={submitText}

--- a/src/packages/survey-form-renderer/src/types.ts
+++ b/src/packages/survey-form-renderer/src/types.ts
@@ -1,5 +1,5 @@
 import type { ReactNode } from "react";
-import type { NodeData, BlockData, LocalizationMap } from "../../../lib/survey/types";
+import type { NodeData, BlockData, LocalizationMap } from "../../survey-form-builder/src/types";
 
 export interface SurveyFormRendererProps {
   survey: {
@@ -99,10 +99,13 @@ export interface SurveyFormContextProps {
   errors: Record<string, string>;
   setError: (field: string, error: string | null) => void;
   currentPage: number;
+  currentBlockIndex: number;
   totalPages: number;
   goToPage: (pageIndex: number) => void;
   goToNextPage: () => void;
   goToPreviousPage: () => void;
+  goToNextBlock: () => void;
+  goToPreviousBlock: () => void;
   isFirstPage: boolean;
   isLastPage: boolean;
   isSubmitting: boolean;

--- a/src/packages/survey-form-renderer/src/utils/conditionalUtils.ts
+++ b/src/packages/survey-form-renderer/src/utils/conditionalUtils.ts
@@ -4,7 +4,7 @@ import type {
   BranchingLogic,
   CalculationRule,
 } from '../types';
-import type { BlockData } from '../../../../lib/survey/types';
+import type { BlockData } from '../../../survey-form-builder/src/types';
 
 /**
  * Evaluates a simple condition between two values using the specified operator
@@ -122,7 +122,13 @@ export function evaluateCondition(
         .replace(/global/g, '')
         .replace(/window/g, '')
         .replace(/document/g, '')
-        .replace(/eval\s*\(/g, '');
+        .replace(/eval\s*\(/g, '')
+        .trim();
+
+      // Allow conditions written as "return x > 0;" by stripping leading return
+      const normalized = sanitizedCondition
+        .replace(/^return\s+/i, '')
+        .replace(/;?\s*$/,'');
 
       // Create a function that references values by using a parameter object instead of 'with'
       const conditionFn = new Function('values', `
@@ -130,7 +136,7 @@ export function evaluateCondition(
         try {
           // Access values directly from the values object
           // Example: If condition is "age > 18", we'll reference values.age
-          const result = (${translateConditionToExplicitReferences(sanitizedCondition)});
+          const result = (${translateConditionToExplicitReferences(normalized)});
           return result;
         } catch (e) {
           console.error("Error evaluating condition:", e);
@@ -266,6 +272,62 @@ export function getNextPageFromNavigationRules(
       }
     }
   }
+  return null;
+}
+
+/**
+ * Find the page and block index for a block UUID
+ */
+export function findBlockPosition(
+  pages: Array<BlockData[]>,
+  target: string
+): { pageIndex: number; blockIndex: number } | null {
+  for (let pIndex = 0; pIndex < pages.length; pIndex++) {
+    const bIndex = pages[pIndex].findIndex((b) => b.uuid === target);
+    if (bIndex >= 0) {
+      return { pageIndex: pIndex, blockIndex: bIndex };
+    }
+  }
+  return null;
+}
+
+/**
+ * Evaluate navigation rules on a single block and return the target position
+ */
+export function getNextStepFromNavigationRules(
+  block: BlockData,
+  pages: Array<BlockData[]>,
+  fieldValues: Record<string, any>
+): { pageIndex: number; blockIndex: number } | 'submit' | null {
+  if (!block.navigationRules) return null;
+
+  for (const rule of block.navigationRules) {
+    if (evaluateCondition(rule.condition, fieldValues)) {
+      if (rule.target === 'submit') {
+        return 'submit';
+      }
+      if (rule.isPage) {
+        const idx = pages.findIndex((p) => p[0]?.uuid === rule.target);
+        if (idx >= 0) return { pageIndex: idx, blockIndex: 0 };
+      } else {
+        const pos = findBlockPosition(pages, String(rule.target));
+        if (pos) return pos;
+      }
+    }
+  }
+
+  const defaultRule = block.navigationRules.find((r) => r.isDefault);
+  if (defaultRule) {
+    if (defaultRule.target === 'submit') return 'submit';
+    if (defaultRule.isPage) {
+      const idx = pages.findIndex((p) => p[0]?.uuid === defaultRule.target);
+      if (idx >= 0) return { pageIndex: idx, blockIndex: 0 };
+    } else {
+      const pos = findBlockPosition(pages, String(defaultRule.target));
+      if (pos) return pos;
+    }
+  }
+
   return null;
 }
 

--- a/src/packages/survey-form-renderer/src/utils/surveyUtils.ts
+++ b/src/packages/survey-form-renderer/src/utils/surveyUtils.ts
@@ -1,4 +1,4 @@
-import type { NodeData, BlockData } from "../../../../lib/survey/types";
+import type { NodeData, BlockData } from "../../../survey-form-builder/src/types";
 
 /**
  * Extracts all pages/sections from a survey


### PR DESCRIPTION
## Summary
- track block index and compute next steps
- update imports to shared builder types
- sanitize conditional expressions that include `return`

## Testing
- `npm run type-check` *(fails: Cannot find modules and other errors)*
- `npm run lint` *(fails: Found 291 lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_6846ea1eda1c832c8dcf60acbcdb07ca