### PR TITLE
Add auth block

### DIFF
--- a/src/packages/survey-form-builder/readme.md
+++ b/src/packages/survey-form-builder/readme.md
@@ -115,6 +115,38 @@ function App() {
 }
 ```
 
+## Authentication Block
+
+The `AuthBlock` allows you to authenticate users before they continue the survey.
+Configure the following fields in the block editor:
+
+- **loginUrl** – endpoint for login requests
+- **signupUrl** – optional endpoint for creating new accounts
+- **useOtp** – enable passwordless authentication
+  - **sendOtpUrl** – endpoint to request the OTP
+  - **verifyOtpUrl** – endpoint to verify the OTP
+- **tokenField** – name of the property containing the token in the API response
+- **tokenStorageKey** – key used to store the token in `localStorage` (default `authToken`)
+- **validateTokenUrl** – optional endpoint to validate an existing token when the block mounts
+- **requireName** – prompt for the user's name
+- **requireEmail** – prompt for the user's email
+- **nameLabel** – label for the name field
+- **emailLabel** – label for the email field
+
+All data returned from your authentication APIs is stored in the form context and included in the final submission JSON.
+
+After successful authentication, the token is saved and the survey automatically continues.
+
+### API Structure
+
+Each endpoint should accept and return JSON. A typical login request sends `{ name, email }` and expects a response containing at least the property defined by `tokenField` (default `token`). When `useOtp` is enabled, `sendOtpUrl` receives `{ name, email }` and `verifyOtpUrl` should verify `{ email, otp }`.
+
+Any extra data returned from these APIs is merged into the form context and can be used later in your survey or submission handler.
+
+### Testing Endpoints
+
+The AuthBlock editor includes a **Test Endpoints** button which issues a simple `GET` request to each configured URL and reports whether it responds successfully. Use this to confirm your URLs are reachable while building your survey.
+
 ## API Reference
 
 ### SurveyBuilder Component

--- a/src/packages/survey-form-builder/src/components/blocks/AuthBlock.tsx
+++ b/src/packages/survey-form-builder/src/components/blocks/AuthBlock.tsx
@@ -1,0 +1,221 @@
+import React from "react";
+import { BlockDefinition, ContentBlockItemProps } from "../../types";
+import { Input } from "@survey-form-builder/components/ui/input";
+import { Label } from "@survey-form-builder/components/ui/label";
+import { Checkbox } from "@survey-form-builder/components/ui/checkbox";
+import { Button } from "@survey-form-builder/components/ui/button";
+import { UserCheck } from "lucide-react";
+
+const AuthBlockForm: React.FC<ContentBlockItemProps> = ({ data, onUpdate }) => {
+  const [testResults, setTestResults] = React.useState<string[]>([]);
+  const handleChange = (field: string, value: any) => {
+    onUpdate?.({
+      ...data,
+      [field]: value,
+    });
+  };
+
+  const testEndpoints = async () => {
+    const endpoints = [
+      { label: "loginUrl", url: data.loginUrl },
+      { label: "signupUrl", url: data.signupUrl },
+      { label: "sendOtpUrl", url: data.sendOtpUrl },
+      { label: "verifyOtpUrl", url: data.verifyOtpUrl },
+      { label: "validateTokenUrl", url: data.validateTokenUrl },
+    ];
+    const results: string[] = [];
+    for (const ep of endpoints) {
+      if (!ep.url) continue;
+      try {
+        const res = await fetch(ep.url, { method: "GET" });
+        results.push(`${ep.label}: ${res.ok ? "ok" : res.status}`);
+      } catch {
+        results.push(`${ep.label}: error`);
+      }
+    }
+    setTestResults(results.length ? results : ["No URLs configured"]);
+  };
+
+  return (
+    <div className="space-y-4">
+      <div className="grid grid-cols-2 gap-4">
+        <div className="space-y-2">
+          <Label htmlFor="loginUrl">Login URL</Label>
+          <Input
+            id="loginUrl"
+            value={data.loginUrl || ""}
+            onChange={(e) => handleChange("loginUrl", e.target.value)}
+            placeholder="https://api.example.com/login"
+          />
+        </div>
+        <div className="space-y-2">
+          <Label htmlFor="signupUrl">Signup URL</Label>
+          <Input
+            id="signupUrl"
+            value={data.signupUrl || ""}
+            onChange={(e) => handleChange("signupUrl", e.target.value)}
+            placeholder="https://api.example.com/signup"
+          />
+        </div>
+      </div>
+
+      <div className="grid grid-cols-2 gap-4">
+        <div className="space-y-2">
+          <Label htmlFor="nameLabel">Name Label</Label>
+          <Input
+            id="nameLabel"
+            value={data.nameLabel || "Name"}
+            onChange={(e) => handleChange("nameLabel", e.target.value)}
+            placeholder="Name"
+          />
+        </div>
+        <div className="space-y-2">
+          <Label htmlFor="emailLabel">Email Label</Label>
+          <Input
+            id="emailLabel"
+            value={data.emailLabel || "Email"}
+            onChange={(e) => handleChange("emailLabel", e.target.value)}
+            placeholder="Email"
+          />
+        </div>
+      </div>
+
+      <div className="flex items-center space-x-2">
+        <Checkbox
+          id="useOtp"
+          checked={!!data.useOtp}
+          onCheckedChange={(checked) => handleChange("useOtp", !!checked)}
+        />
+        <Label htmlFor="useOtp">Use OTP</Label>
+      </div>
+
+      {data.useOtp && (
+        <div className="grid grid-cols-2 gap-4">
+          <div className="space-y-2">
+            <Label htmlFor="sendOtpUrl">Send OTP URL</Label>
+            <Input
+              id="sendOtpUrl"
+              value={data.sendOtpUrl || ""}
+              onChange={(e) => handleChange("sendOtpUrl", e.target.value)}
+              placeholder="https://api.example.com/send-otp"
+            />
+          </div>
+          <div className="space-y-2">
+            <Label htmlFor="verifyOtpUrl">Verify OTP URL</Label>
+            <Input
+              id="verifyOtpUrl"
+              value={data.verifyOtpUrl || ""}
+              onChange={(e) => handleChange("verifyOtpUrl", e.target.value)}
+              placeholder="https://api.example.com/verify-otp"
+            />
+          </div>
+        </div>
+      )}
+
+      <div className="grid grid-cols-2 gap-4">
+        <div className="space-y-2">
+          <Label htmlFor="tokenField">Token Field</Label>
+          <Input
+            id="tokenField"
+            value={data.tokenField || ""}
+            onChange={(e) => handleChange("tokenField", e.target.value)}
+            placeholder="token"
+          />
+        </div>
+        <div className="space-y-2">
+          <Label htmlFor="tokenStorageKey">Token Storage Key</Label>
+          <Input
+            id="tokenStorageKey"
+            value={data.tokenStorageKey || "authToken"}
+            onChange={(e) => handleChange("tokenStorageKey", e.target.value)}
+            placeholder="authToken"
+          />
+        </div>
+      </div>
+
+      <div className="space-y-2">
+        <Label htmlFor="validateTokenUrl">Validate Token URL</Label>
+        <Input
+          id="validateTokenUrl"
+          value={data.validateTokenUrl || ""}
+          onChange={(e) => handleChange("validateTokenUrl", e.target.value)}
+          placeholder="https://api.example.com/validate-token"
+        />
+      </div>
+
+      <div className="grid grid-cols-2 gap-4">
+        <div className="flex items-center space-x-2">
+          <Checkbox
+            id="requireName"
+            checked={!!data.requireName}
+            onCheckedChange={(checked) => handleChange("requireName", !!checked)}
+          />
+          <Label htmlFor="requireName">Require Name</Label>
+        </div>
+        <div className="flex items-center space-x-2">
+          <Checkbox
+            id="requireEmail"
+            checked={!!data.requireEmail}
+            onCheckedChange={(checked) => handleChange("requireEmail", !!checked)}
+          />
+          <Label htmlFor="requireEmail">Require Email</Label>
+        </div>
+      </div>
+
+      <div className="space-y-2">
+        <Button type="button" variant="outline" onClick={testEndpoints}>
+          Test Endpoints
+        </Button>
+        {testResults.length > 0 && (
+          <ul className="list-disc pl-4 text-sm">
+            {testResults.map((r, i) => (
+              <li key={i}>{r}</li>
+            ))}
+          </ul>
+        )}
+      </div>
+    </div>
+  );
+};
+
+const AuthBlockItem: React.FC<ContentBlockItemProps> = () => {
+  return (
+    <div className="p-4 border rounded-md text-center text-sm">
+      Authentication Required
+    </div>
+  );
+};
+
+const AuthBlockPreview: React.FC = () => {
+  return (
+    <div className="w-full flex items-center justify-center py-1 text-sm">
+      <UserCheck className="w-4 h-4 mr-2" /> Auth
+    </div>
+  );
+};
+
+export const AuthBlock: BlockDefinition = {
+  type: "auth",
+  name: "Authentication",
+  description: "Authenticate user before continuing",
+  icon: <UserCheck className="w-4 h-4" />,
+  defaultData: {
+    type: "auth",
+    loginUrl: "",
+    signupUrl: "",
+    useOtp: false,
+    sendOtpUrl: "",
+    verifyOtpUrl: "",
+    tokenField: "token",
+    tokenStorageKey: "authToken",
+    validateTokenUrl: "",
+    requireName: false,
+    requireEmail: true,
+    nameLabel: "Name",
+    emailLabel: "Email",
+  },
+  renderItem: (props) => <AuthBlockItem {...props} />,
+  renderFormFields: (props) => <AuthBlockForm {...props} />,
+  renderPreview: () => <AuthBlockPreview />,
+  validate: () => null,
+};

--- a/src/packages/survey-form-builder/src/components/blocks/index.ts
+++ b/src/packages/survey-form-builder/src/components/blocks/index.ts
@@ -5,6 +5,7 @@ import { CheckboxBlock } from "./CheckboxBlock";
 import { MarkdownBlock } from "./MarkdownBlock";
 import { HtmlBlock } from "./HtmlBlock";
 import { ScriptBlock } from "./ScriptBlock";
+import { AuthBlock } from "./AuthBlock";
 import { SelectBlock } from "./SelectBlock";
 import { RangeBlock } from "./RangeBlock";
 import { DatePickerBlock } from "./DatePickerBlock";
@@ -36,6 +37,7 @@ export const StandardBlocks: BlockDefinition[] = [
   HtmlBlock,
 
   // Logic blocks
+  AuthBlock,
   ScriptBlock,
 
   // Advanced calculation and conditional blocks
@@ -53,6 +55,7 @@ export {
   MarkdownBlock,
   HtmlBlock,
   ScriptBlock,
+  AuthBlock,
   SelectBlock,
   RangeBlock,
   DatePickerBlock,

--- a/src/packages/survey-form-renderer/src/components/blocks/AuthRenderer.tsx
+++ b/src/packages/survey-form-renderer/src/components/blocks/AuthRenderer.tsx
@@ -1,0 +1,172 @@
+import React, { useEffect, useState } from 'react';
+import { BlockRendererProps } from '../../types';
+import { Input } from '../ui/input';
+import { Button } from '../ui/button';
+import { Label } from '../ui/label';
+import { useSurveyForm } from '../../context/SurveyFormContext';
+
+export const AuthRenderer: React.FC<BlockRendererProps> = ({ block }) => {
+  const {
+    goToNextBlock
+  } = useSurveyForm();
+
+  const tokenField = (block as any).tokenField || 'token';
+  const storageKey = (block as any).tokenStorageKey || 'authToken';
+  const nameLabel = (block as any).nameLabel || 'Name';
+  const emailLabel = (block as any).emailLabel || 'Email';
+
+  const [name, setName] = useState('');
+  const [email, setEmail] = useState('');
+  const [otp, setOtp] = useState('');
+  const [step, setStep] = useState<'form' | 'otp' | 'welcome'>('form');
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [apiData, setApiData] = useState<Record<string, any>>({});
+
+  useEffect(() => {
+    const existing = localStorage.getItem(storageKey);
+    if (existing) {
+      if ((block as any).validateTokenUrl) {
+        fetch((block as any).validateTokenUrl, {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ [tokenField]: existing })
+        })
+          .then((res) => res.ok ? res.json() : Promise.reject())
+          .then((data) => {
+            setApiData(data || {});
+            if (data && data.name) setName(data.name);
+            setStep('welcome');
+          })
+          .catch(() => {});
+      } else {
+        setStep('welcome');
+      }
+    }
+  }, []);
+
+  const handleSubmit = async (url?: string) => {
+    if (!url) return;
+    setLoading(true);
+    setError(null);
+    try {
+      if ((block as any).useOtp) {
+        await fetch((block as any).sendOtpUrl || '', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ email, name })
+        });
+        setStep('otp');
+      } else {
+        const res = await fetch(url, {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ name, email })
+        });
+        const data = await res.json();
+        if (res.ok) {
+          setApiData(data || {});
+          if (data[tokenField]) {
+            localStorage.setItem(storageKey, data[tokenField]);
+          }
+          if (data.name) setName(data.name);
+          goToNextBlock({ ...data, [storageKey]: data[tokenField] });
+        } else {
+          setError('Authentication failed');
+        }
+      }
+    } catch (e) {
+      setError('Authentication failed');
+    }
+    setLoading(false);
+  };
+
+  const handleVerify = async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      const res = await fetch((block as any).verifyOtpUrl || '', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ email, otp })
+      });
+      const data = await res.json();
+      if (res.ok) {
+        setApiData(data || {});
+        if (data[tokenField]) {
+          localStorage.setItem(storageKey, data[tokenField]);
+        }
+        if (data.name) setName(data.name);
+        goToNextBlock({ ...data, [storageKey]: data[tokenField] });
+      } else {
+        setError('Verification failed');
+      }
+    } catch (e) {
+      setError('Verification failed');
+    }
+    setLoading(false);
+  };
+
+  if (step === 'welcome') {
+    return (
+      <div className="space-y-4">
+        <p>Welcome back{name ? `, ${name}` : ''}!</p>
+        <Button onClick={() => goToNextBlock({ ...apiData, [storageKey]: localStorage.getItem(storageKey) })}>
+          Continue
+        </Button>
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-4">
+      {step === 'form' && (
+        <>
+          {(block as any).requireName && (
+            <div className="space-y-2">
+              <Label htmlFor="name">{nameLabel}</Label>
+              <Input id="name" value={name} onChange={(e) => setName(e.target.value)} />
+            </div>
+          )}
+          {(block as any).requireEmail && (
+            <div className="space-y-2">
+              <Label htmlFor="email">{emailLabel}</Label>
+              <Input id="email" type="email" value={email} onChange={(e) => setEmail(e.target.value)} />
+            </div>
+          )}
+          <div className="flex space-x-2">
+            {(block as any).loginUrl && (
+              <Button disabled={loading} onClick={() => handleSubmit((block as any).loginUrl)}>
+                {(block as any).useOtp ? 'Send OTP' : 'Login'}
+              </Button>
+            )}
+            {!(block as any).loginUrl && (
+              <Button disabled={loading} onClick={() => handleSubmit((block as any).signupUrl)}>
+                {(block as any).useOtp ? 'Send OTP' : 'Submit'}
+              </Button>
+            )}
+            {Boolean((block as any).signupUrl && (block as any).loginUrl) && (
+              <Button disabled={loading} onClick={() => handleSubmit((block as any).signupUrl)}>
+                Sign Up
+              </Button>
+            )}
+          </div>
+        </>
+      )}
+
+      {step === 'otp' && (
+        <>
+          <div className="space-y-2">
+            <Label htmlFor="otp">Enter OTP</Label>
+            <Input id="otp" value={otp} onChange={(e) => setOtp(e.target.value)} />
+          </div>
+          <Button disabled={loading} onClick={handleVerify}>
+            Verify
+          </Button>
+        </>
+      )}
+
+      {error && <div className="text-destructive text-sm">{error}</div>}
+    </div>
+  );
+};

--- a/src/packages/survey-form-renderer/src/components/blocks/BlockRenderer.tsx
+++ b/src/packages/survey-form-renderer/src/components/blocks/BlockRenderer.tsx
@@ -17,6 +17,7 @@ import { SetRenderer } from './SetRenderer';
 import { ConditionalBlock } from './ConditionalBlock';
 import { CalculatedFieldRenderer } from './CalculatedFieldRenderer';
 import { BMICalculatorRenderer } from './BMICalculatorRenderer';
+import { AuthRenderer } from './AuthRenderer';
 import { themes } from '../../themes';
 import { blockTypeMap, validateBlock } from '../../utils/blockAdapter';
 import { useSurveyForm } from '../../context/SurveyFormContext';
@@ -120,6 +121,8 @@ export const BlockRenderer = forwardRef<HTMLElement, BlockRendererProps>((props,
       return <MarkdownRenderer block={block} {...commonProps} />;
     case 'html':
       return <HtmlRenderer block={block} {...commonProps} />;
+    case 'auth':
+      return <AuthRenderer block={block} {...commonProps} />;
     case 'script':
       return <ScriptRenderer block={block} theme={theme} />;
     case 'set':

--- a/src/packages/survey-form-renderer/src/context/SurveyFormContext.tsx
+++ b/src/packages/survey-form-renderer/src/context/SurveyFormContext.tsx
@@ -443,13 +443,16 @@ export const SurveyFormProvider: React.FC<SurveyFormProviderProps> = ({
       return;
     }
 
-    const currentValues = fValue ?? values;
+    const mergedValues = fValue ? { ...values, ...fValue } : values;
+    if (fValue) {
+      setValues(prev => ({ ...prev, ...fValue }));
+    }
 
     const target = getNextStepFromNavigationRules(
       currentBlock,
       pages,
       pageIds,
-      { ...currentValues, ...computedValues }
+      { ...mergedValues, ...computedValues }
     );
 
     if (target === 'submit') {

--- a/src/packages/survey-form-renderer/src/index.tsx
+++ b/src/packages/survey-form-renderer/src/index.tsx
@@ -15,6 +15,7 @@ import { MatrixRenderer } from './components/blocks/MatrixRenderer';
 import { SelectableBoxRenderer } from './components/blocks/SelectableBoxRenderer';
 import { ScriptRenderer } from './components/blocks/ScriptRenderer';
 import { SetRenderer } from './components/blocks/SetRenderer';
+import { AuthRenderer } from './components/blocks/AuthRenderer';
 import { DebugInfo } from './components/ui/DebugInfo';
 
 // New conditional components
@@ -86,6 +87,7 @@ export {
   SelectableBoxRenderer,
   ScriptRenderer,
   SetRenderer,
+  AuthRenderer,
 
   // UI components
   DebugInfo,

--- a/src/packages/survey-form-renderer/src/utils/blockAdapter.tsx
+++ b/src/packages/survey-form-renderer/src/utils/blockAdapter.tsx
@@ -1,6 +1,6 @@
 import { BlockData, BlockDefinition } from "@survey-form-renderer/types";
 import { Activity } from "lucide-react";
-import { TextInputBlock, TextareaBlock, SelectBlock, RadioBlock, CheckboxBlock, RangeBlock, DatePickerBlock, FileUploadBlock, MatrixBlock, SelectableBoxQuestionBlock, MarkdownBlock, HtmlBlock, ScriptBlock } from "./blockdefinations";
+import { TextInputBlock, TextareaBlock, SelectBlock, RadioBlock, CheckboxBlock, RangeBlock, DatePickerBlock, FileUploadBlock, MatrixBlock, SelectableBoxQuestionBlock, MarkdownBlock, HtmlBlock, ScriptBlock, AuthBlock } from "./blockdefinations";
 
 // Export the block definition
 export const BMICalculatorBlock: BlockDefinition = {
@@ -49,6 +49,7 @@ export const blockTypeMap: Record<string, any> = {
   // Content blocks
   markdown: MarkdownBlock,
   html: HtmlBlock,
+  auth: AuthBlock,
 
   // Logic blocks
   script: ScriptBlock,

--- a/src/packages/survey-form-renderer/src/utils/blockdefinations.tsx
+++ b/src/packages/survey-form-renderer/src/utils/blockdefinations.tsx
@@ -1,5 +1,5 @@
 import { BlockData, BlockDefinition } from "@survey-form-renderer/types";
-import { Activity, AlignLeft, ArrowRightToLine, Calculator, Calendar, CheckSquare, CircleCheck, Code, FileText, GitBranch, Grid3X3, ListFilter, LucideTextCursor, Terminal, Upload } from "lucide-react";
+import { Activity, AlignLeft, ArrowRightToLine, Calculator, Calendar, CheckSquare, CircleCheck, Code, FileText, GitBranch, Grid3X3, ListFilter, LucideTextCursor, Terminal, Upload, UserCheck } from "lucide-react";
 import { v4 as uuidv4 } from "uuid";
 
 // Export the block definition
@@ -182,6 +182,29 @@ export const HtmlBlock: BlockDefinition = {
     if (!data.html) return "HTML content is required";
     return null;
   },
+};
+
+export const AuthBlock: BlockDefinition = {
+  type: "auth",
+  name: "Authentication",
+  description: "Authenticate user before continuing",
+  icon: <UserCheck className="w-4 h-4" />,
+  defaultData: {
+    type: "auth",
+    loginUrl: "",
+    signupUrl: "",
+    useOtp: false,
+    sendOtpUrl: "",
+    verifyOtpUrl: "",
+    tokenField: "token",
+    tokenStorageKey: "authToken",
+    validateTokenUrl: "",
+    requireName: false,
+    requireEmail: true,
+    nameLabel: "Name",
+    emailLabel: "Email",
+  },
+  validate: () => null,
 };
 
 // Export the block definition


### PR DESCRIPTION
## Summary
- add configurable `AuthBlock` in builder
- export `AuthBlock` in block registry
- create `AuthRenderer` and hook up renderer logic
- register auth block in renderer util map and case statement
- document authentication options in builder README
- allow custom name/email labels and preserve API response in context
- document API structure and add endpoint test button

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_685167de8db8832c85ce4e966d7d73fa