### PR TITLE
Rename questionTitle to label

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -62,7 +62,7 @@ const sampleSurvey =
           {
             "type": "selectablebox",
             "fieldName": "allergyHistory",
-            "questionTitle": "Have you ever had an adverse or allergic reaction to testosterone or testosterone replacement support medications?",
+            "label": "Have you ever had an adverse or allergic reaction to testosterone or testosterone replacement support medications?",
             "description": "e.g., testosterone injectable, topical (androgel, testim, bioidentical), clomiphene (clomid), enclomiphene, hcg (human chorionic gonadotropin), gonadorelin, anastrazole (arimadex), or to any of its ingredients?",
             "boxSpacing": "4",
             "defaultValue": "",
@@ -98,7 +98,7 @@ const sampleSurvey =
           {
             "type": "selectablebox",
             "fieldName": "medicalAdvice",
-            "questionTitle": "Have you been advised to avoid hormone replacement due to a medical condition?",
+            "label": "Have you been advised to avoid hormone replacement due to a medical condition?",
             "description": "",
             "boxSpacing": "4",
             "defaultValue": "",
@@ -134,7 +134,7 @@ const sampleSurvey =
           {
             "type": "selectablebox",
             "fieldName": "cancerHistory",
-            "questionTitle": "Have you ever been diagnosed with prostate, breast, or testicular cancer?",
+            "label": "Have you ever been diagnosed with prostate, breast, or testicular cancer?",
             "description": "",
             "boxSpacing": "4",
             "defaultValue": "",
@@ -170,7 +170,7 @@ const sampleSurvey =
           {
             "type": "selectablebox",
             "fieldName": "polycythemia",
-            "questionTitle": "Have you ever been diagnosed with polycythemia (too many red blood cells)?",
+            "label": "Have you ever been diagnosed with polycythemia (too many red blood cells)?",
             "description": "",
             "boxSpacing": "4",
             "defaultValue": "",
@@ -206,7 +206,7 @@ const sampleSurvey =
           {
             "type": "selectablebox",
             "fieldName": "medicalConditions",
-            "questionTitle": "Do you have a personal medical history involving any of the following medical conditions?",
+            "label": "Do you have a personal medical history involving any of the following medical conditions?",
             "description": "",
             "boxSpacing": "4",
             "defaultValue": "",
@@ -290,7 +290,7 @@ const sampleSurvey =
           {
             "type": "selectablebox",
             "fieldName": "medicationHistory",
-            "questionTitle": "Are you currently taking or have you taken any of the following in the past?",
+            "label": "Are you currently taking or have you taken any of the following in the past?",
             "description": "",
             "boxSpacing": "4",
             "defaultValue": "",
@@ -356,7 +356,7 @@ const sampleSurvey =
           {
             "type": "selectablebox",
             "fieldName": "medicationTiming",
-            "questionTitle": "Are you currently taking this medication, or did you take it previously?",
+            "label": "Are you currently taking this medication, or did you take it previously?",
             "description": "Only answer if you selected a medication above (not 'No')",
             "boxSpacing": "4",
             "defaultValue": "",
@@ -403,7 +403,7 @@ const sampleSurvey =
           {
             "type": "selectablebox",
             "fieldName": "libidoRating",
-            "questionTitle": "Rank the following as it applies to you on a scale of 1-5 (5 being greatest): libido (sex drive)",
+            "label": "Rank the following as it applies to you on a scale of 1-5 (5 being greatest): libido (sex drive)",
             "description": "",
             "boxSpacing": "4",
             "defaultValue": "",
@@ -442,7 +442,7 @@ const sampleSurvey =
           {
             "type": "selectablebox",
             "fieldName": "erectionStrength",
-            "questionTitle": "Rank the following as it applies to you on a scale of 1-5 (5 being greatest): erection strength",
+            "label": "Rank the following as it applies to you on a scale of 1-5 (5 being greatest): erection strength",
             "description": "",
             "boxSpacing": "4",
             "defaultValue": "",
@@ -488,7 +488,7 @@ const sampleSurvey =
           {
             "type": "selectablebox",
             "fieldName": "energyLevel",
-            "questionTitle": "Rank the following as it applies to you on a scale of 1-5 (1 is worst, 5 is best): energy level",
+            "label": "Rank the following as it applies to you on a scale of 1-5 (1 is worst, 5 is best): energy level",
             "description": "",
             "boxSpacing": "4",
             "defaultValue": "",
@@ -527,7 +527,7 @@ const sampleSurvey =
           {
             "type": "selectablebox",
             "fieldName": "enjoymentOfLife",
-            "questionTitle": "Rank the following as it applies to you on a scale of 1-5 (1 is worst, 5 is best): enjoyment of life",
+            "label": "Rank the following as it applies to you on a scale of 1-5 (1 is worst, 5 is best): enjoyment of life",
             "description": "",
             "boxSpacing": "4",
             "defaultValue": "",
@@ -566,7 +566,7 @@ const sampleSurvey =
           {
             "type": "selectablebox",
             "fieldName": "depressionFeelings",
-            "questionTitle": "Rank the following as it applies to you on a scale of 1-5 (1 is worst, 5 is best): feelings of depression",
+            "label": "Rank the following as it applies to you on a scale of 1-5 (1 is worst, 5 is best): feelings of depression",
             "description": "",
             "boxSpacing": "4",
             "defaultValue": "",
@@ -605,7 +605,7 @@ const sampleSurvey =
           {
             "type": "selectablebox",
             "fieldName": "anxietyFeelings",
-            "questionTitle": "Rank the following as it applies to you on a scale of 1-5 (1 is worst, 5 is best): feelings of anxiety",
+            "label": "Rank the following as it applies to you on a scale of 1-5 (1 is worst, 5 is best): feelings of anxiety",
             "description": "",
             "boxSpacing": "4",
             "defaultValue": "",
@@ -651,7 +651,7 @@ const sampleSurvey =
           {
             "type": "selectablebox",
             "fieldName": "strengthEndurance",
-            "questionTitle": "Rank the following as it applies to you on a scale of 1-5 (1 is worst, 5 is best): strength and/or endurance?",
+            "label": "Rank the following as it applies to you on a scale of 1-5 (1 is worst, 5 is best): strength and/or endurance?",
             "description": "",
             "boxSpacing": "4",
             "defaultValue": "",
@@ -690,7 +690,7 @@ const sampleSurvey =
           {
             "type": "selectablebox",
             "fieldName": "sportsAbility",
-            "questionTitle": "Rank the following as it applies to you on a scale of 1-5 (1 is worst, 5 is best): ability to play sports",
+            "label": "Rank the following as it applies to you on a scale of 1-5 (1 is worst, 5 is best): ability to play sports",
             "description": "",
             "boxSpacing": "4",
             "defaultValue": "",
@@ -729,7 +729,7 @@ const sampleSurvey =
           {
             "type": "selectablebox",
             "fieldName": "heightLoss",
-            "questionTitle": "Have you lost height?",
+            "label": "Have you lost height?",
             "description": "",
             "boxSpacing": "4",
             "defaultValue": "",
@@ -760,7 +760,7 @@ const sampleSurvey =
           {
             "type": "selectablebox",
             "fieldName": "fertilityConcerns",
-            "questionTitle": "Are you concerned with the side effects of low sperm count and decreased fertility that can occur with Testosterone?",
+            "label": "Are you concerned with the side effects of low sperm count and decreased fertility that can occur with Testosterone?",
             "description": "",
             "boxSpacing": "4",
             "defaultValue": "",

--- a/src/packages/survey-form-builder/src/components/blocks/SelectableBoxQuestionBlock.tsx
+++ b/src/packages/survey-form-builder/src/components/blocks/SelectableBoxQuestionBlock.tsx
@@ -85,11 +85,11 @@ const SelectableBoxQuestionForm: React.FC<ContentBlockItemProps> = ({
         </div>
 
         <div className="space-y-2">
-          <Label htmlFor="questionTitle">Question Title</Label>
+          <Label htmlFor="label">Label</Label>
           <Input
-            id="questionTitle"
-            value={data.questionTitle || ""}
-            onChange={(e) => handleChange("questionTitle", e.target.value)}
+            id="label"
+            value={data.label || ""}
+            onChange={(e) => handleChange("label", e.target.value)}
             placeholder="What's your goal?"
           />
         </div>
@@ -231,8 +231,8 @@ const SelectableBoxQuestionItem: React.FC<ContentBlockItemProps> = ({
 
   return (
     <div className="space-y-4">
-      {data.questionTitle && (
-        <h3 className="text-2xl font-bold">{data.questionTitle}</h3>
+      {data.label && (
+        <h3 className="text-2xl font-bold">{data.label}</h3>
       )}
 
       {data.description && (
@@ -303,7 +303,7 @@ export const SelectableBoxQuestionBlock: BlockDefinition = {
   defaultData: {
     type: "selectablebox",
     fieldName: `boxq${uuidv4().substring(0, 4)}`,
-    questionTitle: "What's your goal?",
+    label: "What's your goal?",
     description: "",
     boxSpacing: "4",
     defaultValue: "",
@@ -320,7 +320,7 @@ export const SelectableBoxQuestionBlock: BlockDefinition = {
   renderPreview: () => <SelectableBoxQuestionPreview />,
   validate: (data) => {
     if (!data.fieldName) return "Field name is required";
-    if (!data.questionTitle) return "Question title is required";
+    if (!data.label) return "Label is required";
     if (!data.options || data.options.length === 0) return "At least one option is required";
     return null;
   },

--- a/src/packages/survey-form-builder/src/survey/SurveryGraph.tsx
+++ b/src/packages/survey-form-builder/src/survey/SurveryGraph.tsx
@@ -363,8 +363,8 @@ export const SurveyGraph: React.FC<SurveyGraphProps> = ({
             width: 280,
             height: 80,
             data: {
-              label: item.fieldName || item.questionTitle || 'Navigation Item',
-              description: item.questionTitle || item.description || '',
+              label: item.fieldName || item.label || 'Navigation Item',
+              description: item.label || item.description || '',
               nodeType: item.type,
               itemType: item.type,
               originalData: item,
@@ -1000,8 +1000,8 @@ export const SurveyGraph: React.FC<SurveyGraphProps> = ({
                           className="text-xs"
                           fill={isDarkMode ? '#cbd5e1' : '#64748b'}
                         >
-                          {`${index + 1}. ${(item.questionTitle || item.fieldName || item.type || 'Item').substring(0, 35)}${
-                            (item.questionTitle || item.fieldName || item.type || 'Item').length > 35 ? '...' : ''
+                          {`${index + 1}. ${(item.label || item.fieldName || item.type || 'Item').substring(0, 35)}${
+                            (item.label || item.fieldName || item.type || 'Item').length > 35 ? '...' : ''
                           }`}
                         </text>
                         {item.navigationRules && item.navigationRules.length > 0 && (
@@ -1216,7 +1216,7 @@ export const SurveyGraph: React.FC<SurveyGraphProps> = ({
                   {selectedNodeData.data.pageItems.map((item: any, index: number) => (
                     <div key={item.uuid || index} className="flex items-center justify-between text-xs">
                       <span className="text-gray-600 dark:text-gray-300">
-                        {item.fieldName || item.questionTitle || item.type || 'Item'}
+                        {item.fieldName || item.label || item.type || 'Item'}
                       </span>
                       {item.navigationRules && item.navigationRules.length > 0 && (
                         <div className="w-2 h-2 bg-orange-500 rounded-full" title="Has navigation rules"></div>

--- a/src/packages/survey-form-builder/src/survey/helpers/LocalizationEditor.tsx
+++ b/src/packages/survey-form-builder/src/survey/helpers/LocalizationEditor.tsx
@@ -220,9 +220,8 @@ const extractLabelsFromSurvey = (node: any): string[] => {
 
     // Extract text content from the current node itself
     if (currentNode.name) labels.add(currentNode.name);
-    if (currentNode.questionTitle) labels.add(currentNode.questionTitle);
-    if (currentNode.description) labels.add(currentNode.description);
     if (currentNode.label) labels.add(currentNode.label);
+    if (currentNode.description) labels.add(currentNode.description);
     if (currentNode.text) labels.add(currentNode.text);
     if (currentNode.html) labels.add(currentNode.html);
     if (currentNode.placeholder) labels.add(currentNode.placeholder);

--- a/src/packages/survey-form-renderer/src/components/blocks/SelectableBoxRenderer.tsx
+++ b/src/packages/survey-form-renderer/src/components/blocks/SelectableBoxRenderer.tsx
@@ -62,12 +62,12 @@ export const SelectableBoxRenderer: React.FC<SelectableBoxRendererProps> = ({
   
   return (
     <div className="survey-box-question space-y-4">
-      {/* Question Title */}
-      {block.questionTitle && (
+      {/* Label */}
+      {block.label && (
         <Label
           className={cn("text-lg font-bold block", themeConfig.field.label)}
         >
-          {block.questionTitle}
+          {block.label}
         </Label>
       )}
       

--- a/src/packages/survey-form-renderer/src/utils/blockdefinations.tsx
+++ b/src/packages/survey-form-renderer/src/utils/blockdefinations.tsx
@@ -361,7 +361,7 @@ export const SelectableBoxQuestionBlock: BlockDefinition = {
   defaultData: {
     type: "selectablebox",
     fieldName: `boxq${uuidv4().substring(0, 4)}`,
-    questionTitle: "What's your goal?",
+    label: "What's your goal?",
     description: "",
     boxSpacing: "4",
     defaultValue: "",
@@ -375,7 +375,7 @@ export const SelectableBoxQuestionBlock: BlockDefinition = {
   },
   validate: (data) => {
     if (!data.fieldName) return "Field name is required";
-    if (!data.questionTitle) return "Question title is required";
+    if (!data.label) return "Label is required";
     if (!data.options || data.options.length === 0) return "At least one option is required";
     return null;
   },


### PR DESCRIPTION
## Summary
- rename `questionTitle` field to `label` across builder and renderer
- adjust default data and validation for `SelectableBoxQuestionBlock`
- update graph, localization helper and examples for new field

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_685a6aed111c832c830b8d3eb8b9f9f3