### PR TITLE
fix(authv2): mobile stacking on name block + drop feet fallback

### DIFF
--- a/src/app/emr-demo/custom-blocks/authv2/NameInformationBlock.tsx
+++ b/src/app/emr-demo/custom-blocks/authv2/NameInformationBlock.tsx
@@ -313,7 +313,7 @@ const NameInformationRenderer = React.forwardRef<
         Let's start with some basic information.
       </h2>
 
-      <div className="grid grid-cols-2 gap-4">
+      <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
         <div className="flex flex-col gap-2">
           <Label
             htmlFor={`${block.fieldName}-firstName`}

--- a/src/app/emr-demo/custom-blocks/authv2/VitalsBlock.tsx
+++ b/src/app/emr-demo/custom-blocks/authv2/VitalsBlock.tsx
@@ -176,7 +176,7 @@ const VitalsRenderer = React.forwardRef<HTMLDivElement, BlockRendererProps>(
     const fieldName = block.fieldName || "vitals";
     const existing = values?.[fieldName] || {};
     const [vitalValues, setVitalValues] = useState<Record<string, any>>({
-      feet: existing.feet || 5,
+      feet: existing.feet ?? "",
       inches: existing.inches ?? "",
       weight: existing.weight ?? "",
       systolic: existing.systolic ?? "",


### PR DESCRIPTION
## Summary
- Stack name inputs vertically on mobile (`grid-cols-1 sm:grid-cols-2`)
- Remove default `5` fallback for height feet — start empty

## Test plan
- [ ] Verify name block stacks on <640px width
- [ ] Verify vitals feet field renders empty by default

🤖 Generated with [Claude Code](https://claude.com/claude-code)